### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,7 +1,34 @@
 # PrincessHildaStaff
 Arduino Princess Hilda Cosplay LED staff
 
+Arduino Gemma and Neopixel LEDs to give some life to my 3D Printed Princess Hilda Staff: Zelda Link Between Worlds.
+
 
 https://www.hackster.io/AmieDD/zelda-princess-hilda-led-staff-powered-by-arduino-9a85de
+## Things used in this project
+=====
+Hardware components
+NeoPixel Ring: WS2812 5050 RGB LED	
+Adafruit NeoPixel Ring: WS2812 5050 RGB LED
+Neopixel Ring 12 for the lower part of the staff
+×	1	
+Arduino Gemma	
+Arduino Gemma
+×	2	
+Adafruit Li-Ion Battery 150mAh
+×	1	
+Adafruit Neopixel Stick
+NeoPixel Sticks for the Triforce
+×	2	
+Software apps and online services
+Arduino IDE	
+Arduino IDE
+Hand tools and fabrication machines
+Soldering iron (generic)	
+Soldering iron (generic)
 
 ![Princess Hilda Staff](http://amiedd.com/blogimageuploads/princess-hilda-costume.jpg)
+
+## Schematics
+
+[![Run on Repl.it](https://repl.it/badge/github/AmieDD/PrincessHildaStaff)](https://repl.it/github/AmieDD/PrincessHildaStaff)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AmieDD/PrincessHildaStaff).